### PR TITLE
Specify format to avoid fragile guessing.

### DIFF
--- a/export.py
+++ b/export.py
@@ -195,7 +195,7 @@ def tiff_export(raw_ref, processed_refs):
         for i in range(num_frames):
             filename = f"{start_doc['scan_id']}-{start_doc['sample_name']}-{STREAM_NAME}-{field}-{i}.tiff"
             logger.info(f"Exporting {filename}")
-            dataset.export(directory / filename, slice=(i))
+            dataset.export(directory / filename, slice=(i), format="image/tiff")
 
     logger.info(f"wrote tiff files to: {directory}")
 


### PR DESCRIPTION
A `.` in the `sample_name` metadata from Run `5aba1196-f1f4-4d70-b0ce-81aac030b87f` (and others) led to a `filename` with a `.` in it:

```py
filename = f"{start_doc['scan_id']}-{start_doc['sample_name']}-{STREAM_NAME}-{field}-{i}.tiff"
```

which confused Tiled's format-guessing code. Best to just specify the format.