### PR TITLE
FIX: dark frame array broadcast

### DIFF
--- a/export.py
+++ b/export.py
@@ -99,7 +99,7 @@ def write_dark_subtraction(ref):
         dark = numpy.clip(dark, a_min=0, a_max=None)
 
         return numpy.clip(
-            light - dark.reindex_like(light, "ffill"), a_min=0, a_max=None
+            light - dark.reindex_like(light, "ffill").data, a_min=0, a_max=None
         ).astype(light.dtype)
 
     run = tiled_client_raw[ref]


### PR DESCRIPTION
TIL Xarray will resist array broadcasting because it treats dimensions like things that should be labeled and wants you to be extra explicit.

For dark frames, it seems appropriate to drop this to a numpy array, and then xarray will do the broadcasting. 