### PR TITLE
Update .pre-commit-config repo versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
+
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
     hooks:
@@ -13,15 +14,16 @@ repos:
     -   id: check-yaml
     -   id: debug-statements
 
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 4.0.1
+-   repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
     hooks:
     -   id: flake8
 
--   repo: https://github.com/timothycrosley/isort
-    rev: 5.9.3
+-   repo: https://github.com/pycqa/isort
+    rev: 5.12.0
     hooks:
     -   id: isort
+        args: ["--profile", "black"]
 
 -   repo: https://github.com/psf/black
     rev: 22.3.0


### PR DESCRIPTION
Additionally switches flake8 repo from gitlab to GitHub, which does not require login to access.