### PR TITLE
Add access_tags when writing to sandbox

### DIFF
--- a/export.py
+++ b/export.py
@@ -148,6 +148,7 @@ def write_dark_subtraction(ref):
                 "raw_uid": full_uid,
                 "operation": "dark subtraction",
             },
+            access_tags=["rsoxs_sandbox"],
         )
         results[field] = processed_array_client.item["id"]
 


### PR DESCRIPTION
Due to the tiled updates, access tags need to be added when writing data to tiled.