### PR TITLE
Fix failing flows after env update

### DIFF
--- a/export.py
+++ b/export.py
@@ -98,7 +98,7 @@ def write_dark_subtraction(ref):
         dark = numpy.clip(dark, a_min=0, a_max=None)
 
         return numpy.clip(
-            light - dark.reindex_like(light, "ffill").data, a_min=0, a_max=None
+            light - dark.reindex_like(light, method="ffill").data, a_min=0, a_max=None
         ).astype(light.dtype)
 
     run = tiled_client_raw[ref]


### PR DESCRIPTION
There was an error with xarray reindex_like because positional args were made keyword only. This PR adds the keyword